### PR TITLE
Adding support for .Net 40 Directory methods

### DIFF
--- a/System.IO.Abstractions.Net40/DirectoryBase.Net40.cs
+++ b/System.IO.Abstractions.Net40/DirectoryBase.Net40.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace System.IO.Abstractions
+{
+    public abstract partial class DirectoryBase
+    {
+        public abstract IEnumerable<string> EnumerateFiles(string path);
+        public abstract IEnumerable<string> EnumerateFiles(string path, string searchPattern);
+        public abstract IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption);
+    }
+}

--- a/System.IO.Abstractions.Net40/DirectoryWrapper.Net40.cs
+++ b/System.IO.Abstractions.Net40/DirectoryWrapper.Net40.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+namespace System.IO.Abstractions
+{
+    public partial class DirectoryWrapper
+    {
+        public override IEnumerable<string> EnumerateFiles(string path)
+        {
+            return Directory.EnumerateFiles(path);
+        }
+
+        public override IEnumerable<string> EnumerateFiles(string path, string searchPattern)
+        {
+            return Directory.EnumerateFiles(path, searchPattern);
+        }
+
+        public override IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption)
+        {
+            return Directory.EnumerateFiles(path, searchPattern, searchOption);
+        }
+    }
+}

--- a/System.IO.Abstractions.Net40/System.IO.Abstractions.Net40.csproj
+++ b/System.IO.Abstractions.Net40/System.IO.Abstractions.Net40.csproj
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7964E5A3-666C-4ECA-A0E3-FD12062B416E}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>System.IO.Abstractions</RootNamespace>
+    <AssemblyName>System.IO.Abstractions</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\StrongName.pfx</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\System.IO.Abstractions\Converters.cs" />
+    <Compile Include="..\System.IO.Abstractions\DirectoryBase.cs" />
+    <Compile Include="..\System.IO.Abstractions\DirectoryInfoBase.cs" />
+    <Compile Include="..\System.IO.Abstractions\DirectoryInfoFactory.cs" />
+    <Compile Include="..\System.IO.Abstractions\DirectoryInfoWrapper.cs" />
+    <Compile Include="..\System.IO.Abstractions\DirectoryWrapper.cs" />
+    <Compile Include="..\System.IO.Abstractions\FileInfoBase.cs" />
+    <Compile Include="..\System.IO.Abstractions\FileInfoFactory.cs" />
+    <Compile Include="..\System.IO.Abstractions\FileInfoWrapper.cs" />
+    <Compile Include="..\System.IO.Abstractions\FileSystem.cs" />
+    <Compile Include="..\System.IO.Abstractions\FileSystemInfoBase.cs" />
+    <Compile Include="..\System.IO.Abstractions\FileWrapper.cs" />
+    <Compile Include="..\System.IO.Abstractions\FileBase.cs" />
+    <Compile Include="..\System.IO.Abstractions\IDirectoryInfoFactory.cs" />
+    <Compile Include="..\System.IO.Abstractions\IFileInfoFactory.cs" />
+    <Compile Include="..\System.IO.Abstractions\IFileSystem.cs" />
+    <Compile Include="..\System.IO.Abstractions\PathBase.cs" />
+    <Compile Include="..\System.IO.Abstractions\PathWrapper.cs" />
+    <Compile Include="..\System.IO.Abstractions\Properties\AssemblyInfo.cs">
+      <Link>Properties\AssemblyInfo</Link>
+    </Compile>
+    <Compile Include="DirectoryBase.Net40.cs" />
+    <Compile Include="DirectoryWrapper.Net40.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/System.IO.Abstractions.sln
+++ b/System.IO.Abstractions.sln
@@ -7,6 +7,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.Abstractions", "System.IO.Abstractions\System.IO.Abstractions.csproj", "{4D398F3A-0784-4401-93CD-46CD2FBD6B92}"
+	ProjectSection(ProjectDependencies) = postProject
+		{7964E5A3-666C-4ECA-A0E3-FD12062B416E} = {7964E5A3-666C-4ECA-A0E3-FD12062B416E}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestingHelpers", "TestingHelpers\TestingHelpers.csproj", "{251BD5E5-8133-47A4-AB19-17CF0F43D6AE}"
 EndProject
@@ -18,6 +21,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{7640A0
 		.nuget\NuGet.exe = .nuget\NuGet.exe
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.Abstractions.Net40", "System.IO.Abstractions.Net40\System.IO.Abstractions.Net40.csproj", "{7964E5A3-666C-4ECA-A0E3-FD12062B416E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestingHelpers.Net40", "TestingHelpers.Net40\TestingHelpers.Net40.csproj", "{DED3CE2A-7323-412D-BB6A-F55C0AC1F149}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -37,6 +44,14 @@ Global
 		{20B02738-952A-40F5-9C10-E2F83013E9FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{20B02738-952A-40F5-9C10-E2F83013E9FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{20B02738-952A-40F5-9C10-E2F83013E9FC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7964E5A3-666C-4ECA-A0E3-FD12062B416E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7964E5A3-666C-4ECA-A0E3-FD12062B416E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7964E5A3-666C-4ECA-A0E3-FD12062B416E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7964E5A3-666C-4ECA-A0E3-FD12062B416E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DED3CE2A-7323-412D-BB6A-F55C0AC1F149}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DED3CE2A-7323-412D-BB6A-F55C0AC1F149}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DED3CE2A-7323-412D-BB6A-F55C0AC1F149}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DED3CE2A-7323-412D-BB6A-F55C0AC1F149}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/System.IO.Abstractions/DirectoryBase.cs
+++ b/System.IO.Abstractions/DirectoryBase.cs
@@ -3,7 +3,7 @@
 namespace System.IO.Abstractions
 {
     [Serializable]
-    public abstract class DirectoryBase
+    public abstract partial class DirectoryBase
     {
         public abstract DirectoryInfoBase CreateDirectory(string path);
         public abstract DirectoryInfoBase CreateDirectory(string path, DirectorySecurity directorySecurity);

--- a/System.IO.Abstractions/DirectoryWrapper.cs
+++ b/System.IO.Abstractions/DirectoryWrapper.cs
@@ -3,7 +3,7 @@
 namespace System.IO.Abstractions
 {
     [Serializable]
-    public class DirectoryWrapper : DirectoryBase
+    public partial class DirectoryWrapper : DirectoryBase
     {
         public override DirectoryInfoBase CreateDirectory(string path)
         {

--- a/System.IO.Abstractions/System.IO.Abstractions.nuspec
+++ b/System.IO.Abstractions/System.IO.Abstractions.nuspec
@@ -11,4 +11,7 @@
     <description>Just like System.Web.Abstractions, but for System.IO. Yay for testable IO access! Be sure to check out the System.IO.Abstractions.TestingHelpers package too.</description>
     <tags>testing</tags>
   </metadata>
+  <files>
+    <file src="..\System.IO.Abstractions.Net40\bin\$configuration$\System.IO.Abstractions.dll" target="lib\net40" />
+  </files>
 </package>

--- a/TestingHelpers.Net40/MockDirectory.Net40.cs
+++ b/TestingHelpers.Net40/MockDirectory.Net40.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+namespace System.IO.Abstractions.TestingHelpers
+{
+    public partial class MockDirectory : DirectoryBase
+    {
+        public override IEnumerable<string> EnumerateFiles(string path)
+        {
+            return GetDirectories(path);
+        }
+
+        public override IEnumerable<string> EnumerateFiles(string path, string searchPattern)
+        {
+            return GetDirectories(path, searchPattern);
+        }
+
+        public override IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption)
+        {
+            return GetDirectories(path, searchPattern, searchOption);
+        }
+    }
+}

--- a/TestingHelpers.Net40/TestingHelpers.Net40.csproj
+++ b/TestingHelpers.Net40/TestingHelpers.Net40.csproj
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{DED3CE2A-7323-412D-BB6A-F55C0AC1F149}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>System.IO.Abstractions.TestingHelpers</RootNamespace>
+    <AssemblyName>System.IO.Abstractions.TestingHelpers</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>..\StrongName.pfx</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\TestingHelpers\IMockFileDataAccessor.cs" />
+    <Compile Include="..\TestingHelpers\MockDirectory.cs" />
+    <Compile Include="..\TestingHelpers\MockDirectoryData.cs" />
+    <Compile Include="..\TestingHelpers\MockDirectoryInfo.cs" />
+    <Compile Include="..\TestingHelpers\MockDirectoryInfoFactory.cs" />
+    <Compile Include="..\TestingHelpers\MockFile.cs" />
+    <Compile Include="..\TestingHelpers\MockFileData.cs" />
+    <Compile Include="..\TestingHelpers\MockFileInfo.cs" />
+    <Compile Include="..\TestingHelpers\MockFileInfoFactory.cs" />
+    <Compile Include="..\TestingHelpers\MockFileStream.cs" />
+    <Compile Include="..\TestingHelpers\MockFileSystem.cs" />
+    <Compile Include="..\TestingHelpers\MockPath.cs" />
+    <Compile Include="..\TestingHelpers\Properties\AssemblyInfo.cs">
+      <Link>Properties\AssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\TestingHelpers\StringExtensions.cs" />
+    <Compile Include="MockDirectory.Net40.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\System.IO.Abstractions.Net40\System.IO.Abstractions.Net40.csproj">
+      <Project>{7964e5a3-666c-4eca-a0e3-fd12062b416e}</Project>
+      <Name>System.IO.Abstractions.Net40</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/TestingHelpers/MockDirectory.cs
+++ b/TestingHelpers/MockDirectory.cs
@@ -7,7 +7,7 @@ using System.Text.RegularExpressions;
 namespace System.IO.Abstractions.TestingHelpers
 {
     [Serializable]
-    public class MockDirectory : DirectoryBase
+    public partial class MockDirectory : DirectoryBase
     {
         readonly FileBase fileBase;
         readonly IMockFileDataAccessor mockFileDataAccessor;

--- a/TestingHelpers/TestingHelpers.nuspec
+++ b/TestingHelpers/TestingHelpers.nuspec
@@ -14,4 +14,7 @@
       <dependency id="System.IO.Abstractions" />
     </dependencies>
   </metadata>
+  <files>
+    <file src="..\TestHelpers.Net40\bin\$configuration$\TestHelpers.dll" target="lib\net40" />
+  </files>
 </package>


### PR DESCRIPTION
A few methods were introduced to the System.IO types in .Net40. I was specifically interested in the Directory.EnumerateFiles method. 

There seems to be a bug in NuGet.exe at this point which causes it to not pick up the assembly from the Net40 project. I can get you a fix for that independently.