### PR TITLE
File modify

### DIFF
--- a/TestHelpers.Tests/MockFileTests.cs
+++ b/TestHelpers.Tests/MockFileTests.cs
@@ -72,7 +72,24 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 fileSystem.File.ReadAllText(path2));
             Assert.AreEqual(
                 "some text",
-                fileSystem.File.ReadAllText(path3, Encoding.Unicode));
+                fileSystem.File.ReadAllText(path3));
+        }
+
+        [Test]
+        public void MockFile_AppendAllText_ShouldCreateIfNotExistWithBom()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            var path = @"c:\something\demo3.txt";
+            fileSystem.AddDirectory(@"c:\something\");
+
+            // Act
+            fileSystem.File.AppendAllText(path, "AA", Encoding.UTF32);
+
+            // Assert
+            CollectionAssert.AreEqual(
+              new byte[] { 255, 254, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0},
+              fileSystem.GetFile(path).Contents);
         }
 
         [Test]

--- a/TestHelpers.Tests/MockFileTests.cs
+++ b/TestHelpers.Tests/MockFileTests.cs
@@ -621,6 +621,23 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 fileSystem.GetFile(path).TextContents);
         }
 
+        [TestCaseSource("GetEncodings")]
+        public void MockFile_WriteAllText_Encoding_ShouldWriteTextFileWithCorrectBOM(Encoding encoding)
+        {
+            // Arrange
+            const string path = @"c:\something\demo.txt";
+            const string fileContent = "Hello there! Dzięki.";
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            fileSystem.File.WriteAllText(path, fileContent, encoding);
+
+            // Assert
+            Assert.AreEqual(
+                encoding.GetPreamble().Concat(encoding.GetBytes(fileContent)),
+                fileSystem.GetFile(path).Contents);
+        }
+
         [Test]
         public void MockFile_Move_ShouldMoveFileWithinMemoryFileSystem()
         {

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -1,10 +1,11 @@
 ﻿using System.Diagnostics;
+using System.Linq;
 using System.Security.AccessControl;
 using System.Text;
 
 namespace System.IO.Abstractions.TestingHelpers
 {
-    [Serializable]
+  [Serializable]
     public class MockFile : FileBase
     {
         readonly IMockFileDataAccessor mockFileDataAccessor;
@@ -49,9 +50,8 @@ namespace System.IO.Abstractions.TestingHelpers
             else
             {
                 var file = mockFileDataAccessor.GetFile(path);
-                var originalText = encoding.GetString(file.Contents);
-                var newText = originalText + contents;
-                file.Contents = encoding.GetBytes(newText);
+                var bytesToAppend = encoding.GetBytes(contents);
+                file.Contents = file.Contents.Concat(bytesToAppend).ToArray();
             }
         }
 
@@ -62,7 +62,6 @@ namespace System.IO.Abstractions.TestingHelpers
                 StreamWriter sw = new StreamWriter(OpenWrite(path));
                 sw.BaseStream.Seek(0, SeekOrigin.End); //push the stream pointer at the end for append.
                 return sw;
-
             }
 
             return new StreamWriter(Create(path));

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace System.IO.Abstractions.TestingHelpers
 {
-  [Serializable]
+    [Serializable]
     public class MockFile : FileBase
     {
         readonly IMockFileDataAccessor mockFileDataAccessor;
@@ -19,21 +19,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override void AppendAllText(string path, string contents)
         {
-            if (!mockFileDataAccessor.FileExists(path))
-            {
-                var dir = mockFileDataAccessor.Path.GetDirectoryName(path);
-                if (!mockFileDataAccessor.Directory.Exists(dir))
-                {
-                    throw new DirectoryNotFoundException(String.Format("Could not find a part of the path '{0}'.", path));
-                }
-                mockFileDataAccessor.AddFile(path, new MockFileData(contents));
-            }
-            else
-            {
-                mockFileDataAccessor
-                    .GetFile(path)
-                    .TextContents += contents;
-            }
+            AppendAllText(path, contents, MockFileData.DefaultEncoding);
         }
 
         public override void AppendAllText(string path, string contents, Encoding encoding)
@@ -45,7 +31,10 @@ namespace System.IO.Abstractions.TestingHelpers
                 {
                     throw new DirectoryNotFoundException(String.Format("Could not find a part of the path '{0}'.", path));
                 }
-                mockFileDataAccessor.AddFile(path, new MockFileData(encoding.GetBytes(contents)));
+
+                // write contents with BOM
+                var content = encoding.GetPreamble().Concat(encoding.GetBytes(contents)).ToArray();
+                mockFileDataAccessor.AddFile(path, new MockFileData(content));
             }
             else
             {

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -64,10 +64,8 @@ namespace System.IO.Abstractions.TestingHelpers
                 return sw;
 
             }
-            else
-            {
-                return new StreamWriter(Create(path));
-            }
+
+            return new StreamWriter(Create(path));
         }
 
         public override void Copy(string sourceFileName, string destFileName)

--- a/TestingHelpers/MockFileData.cs
+++ b/TestingHelpers/MockFileData.cs
@@ -21,7 +21,7 @@ namespace System.IO.Abstractions.TestingHelpers
         private FileAttributes attributes = FileAttributes.Normal;
 
         public virtual bool IsDirectory { get { return false; } }
-        
+
         public MockFileData(string textContents)
             : this(DefaultEncoding.GetBytes(textContents))
         {}
@@ -31,11 +31,27 @@ namespace System.IO.Abstractions.TestingHelpers
         { }
 
         public MockFileData(byte[] contents)
-            : this(contents, DefaultEncoding)
-        { }
+        {
+          if (contents == null)
+          {
+            throw new ArgumentNullException("contents");
+          }
+
+          this.contents = contents;
+        }
 
         public MockFileData(byte[] contents, Encoding encoding)
         {
+          if (contents == null)
+          {
+            throw new ArgumentNullException("contents");
+          }
+
+          if (encoding == null)
+          {
+            throw new ArgumentNullException("encoding");
+          }
+
           this.contents = encoding.GetPreamble().Concat(contents).ToArray();
         }
 


### PR DESCRIPTION
The changes are necessary, because some methods have not persisted the existing BOM and mixed up the content of an existing file.

The default encoding for files is UTF-8 without BOM, like in .Net.
MockFileData.TextContents uses the default encoding, too. 
So setting value via TextContent can destroy the encoding of the file. I am not satisfied with this implementation. However it matches the behavior of .Net very close.

Adapted two test cases, because they were not correct.

@tathamoddie if you need help, just ask