### PR TITLE
fixed assertion to be valid on a non english os

### DIFF
--- a/TestHelpers.Tests/MockDirectoryTests.cs
+++ b/TestHelpers.Tests/MockDirectoryTests.cs
@@ -444,8 +444,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Arrange
             var fileSystem = new MockFileSystem();
 
+            // Act
             var ex = Assert.Throws<ArgumentException>(() => fileSystem.Directory.CreateDirectory(XFS.Path(@"\\server", () => false)));
-            Assert.That(ex.Message, Is.EqualTo("The UNC path should be of the form \\\\server\\share.\r\nParameter name: path"));
+
+            // Assert
+            StringAssert.StartsWith("The UNC path should be of the form \\\\server\\share.", ex.Message);
+            Assert.That(ex.ParamName, Is.EqualTo("path"));
         }
 
         [Test]


### PR DESCRIPTION
the test fails on a non english os. "Parameter name: path" part is then different.