### PR TITLE
add overloads for Path.Combine

### DIFF
--- a/System.IO.Abstractions/PathBase.cs
+++ b/System.IO.Abstractions/PathBase.cs
@@ -11,7 +11,10 @@
         public abstract char VolumeSeparatorChar { get; }
 
         public abstract string ChangeExtension(string path, string extension);
+        public abstract string Combine(params string[] paths);
         public abstract string Combine(string path1, string path2);
+        public abstract string Combine(string path1, string path2, string path3);
+        public abstract string Combine(string path1, string path2, string path3, string path4);
         public abstract string GetDirectoryName(string path);
         public abstract string GetExtension(string path);
         public abstract string GetFileName(string path);

--- a/System.IO.Abstractions/PathWrapper.cs
+++ b/System.IO.Abstractions/PathWrapper.cs
@@ -34,9 +34,24 @@
             return Path.ChangeExtension(path, extension);
         }
 
+        public override string Combine(params string[] paths)
+        {
+            return Path.Combine(paths);
+        }
+
         public override string Combine(string path1, string path2)
         {
             return Path.Combine(path1, path2);
+        }
+
+        public override string Combine(string path1, string path2, string path3)
+        {
+            return Path.Combine(path1, path2, path3);
+        }
+
+        public override string Combine(string path1, string path2, string path3, string path4)
+        {
+            return Path.Combine(path1, path2, path3, path4);
         }
 
         public override string GetDirectoryName(string path)

--- a/TestHelpers.Tests/MockPathTests.cs
+++ b/TestHelpers.Tests/MockPathTests.cs
@@ -41,6 +41,45 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void Combine_SentThreePaths_Combines()
+        {
+            //Arrange
+            var mockPath = new MockPath(new MockFileSystem());
+
+            //Act
+            var result = mockPath.Combine(XFS.Path("C:\\test"), "subdir1", "test.bmp");
+
+            //Assert
+            Assert.AreEqual(XFS.Path("C:\\test\\subdir1\\test.bmp"), result);
+        }
+
+        [Test]
+        public void Combine_SentFourPaths_Combines()
+        {
+            //Arrange
+            var mockPath = new MockPath(new MockFileSystem());
+
+            //Act
+            var result = mockPath.Combine(XFS.Path("C:\\test"), "subdir1", "subdir2", "test.bmp");
+
+            //Assert
+            Assert.AreEqual(XFS.Path("C:\\test\\subdir1\\subdir2\\test.bmp"), result);
+        }
+
+        [Test]
+        public void Combine_SentFivePaths_Combines()
+        {
+            //Arrange
+            var mockPath = new MockPath(new MockFileSystem());
+
+            //Act
+            var result = mockPath.Combine(XFS.Path("C:\\test"), "subdir1", "subdir2", "subdir3", "test.bmp");
+
+            //Assert
+            Assert.AreEqual(XFS.Path("C:\\test\\subdir1\\subdir2\\subdir3\\test.bmp"), result);
+        }
+
+        [Test]
         public void GetDirectoryName_SentPath_ReturnsDirectory()
         {
             //Arrange


### PR DESCRIPTION
Add the new overloads for Path.Combine. They're coming with 4.0...
