### PR TITLE
Match exceptions

### DIFF
--- a/TestHelpers.Tests/MockFileTests.cs
+++ b/TestHelpers.Tests/MockFileTests.cs
@@ -811,25 +811,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [TestCase('>')]
         [TestCase('<')]
         [TestCase('"')]
-        public void MockFile_Move_ShouldThrowArgumentExceptionWhenSourceContainsInvalidChars_ParamName(char invalidChar) {
-            if (XFS.IsUnixPlatform())
-            {
-                Assert.Pass("Path.GetInvalidChars() does not return anything on Mono");
-                return;
-            }
-
-            var sourceFilePath = XFS.Path(@"c:\something\demo.txt") + invalidChar;
-            string destFilePath = XFS.Path(@"c:\something\demo.txt");
-            var fileSystem = new MockFileSystem();
-
-            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
-
-            Assert.That(exception.ParamName, Is.EqualTo("sourceFileName"));
-        }
-
-        [TestCase('>')]
-        [TestCase('<')]
-        [TestCase('"')]
         public void MockFile_Move_ShouldThrowArgumentExceptionWhenTargetContainsInvalidChars_Message(char invalidChar) 
         {
             if (XFS.IsUnixPlatform())
@@ -845,25 +826,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
 
             Assert.That(exception.Message, Is.StringStarting("Illegal characters in path."));
-        }
-
-        [TestCase('>')]
-        [TestCase('<')]
-        [TestCase('"')]
-        public void MockFile_Move_ShouldThrowArgumentExceptionWhenTargetContainsInvalidChars_ParamName(char invalidChar) {
-            if (XFS.IsUnixPlatform())
-            {
-                Assert.Pass("Path.GetInvalidChars() does not return anything on Mono");
-                return;
-            }
-
-            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
-            var destFilePath = XFS.Path(@"c:\something\demo.txt") + invalidChar;
-            var fileSystem = new MockFileSystem();
-
-            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
-
-            Assert.That(exception.ParamName, Is.EqualTo("destFileName"));
         }
 
         [Test]

--- a/TestHelpers.Tests/MockFileTests.cs
+++ b/TestHelpers.Tests/MockFileTests.cs
@@ -1109,6 +1109,201 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockFile_Copy_ShouldThrowArgumentNullExceptionWhenSourceIsNull_Message()
+        {
+            string destFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => fileSystem.File.Copy(null, destFilePath));
+
+            Assert.That(exception.Message, Is.StringStarting("File name cannot be null."));
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowArgumentNullExceptionWhenSourceIsNull_ParamName()
+        {
+            string destFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => fileSystem.File.Copy(null, destFilePath));
+
+            Assert.That(exception.ParamName, Is.EqualTo("sourceFileName"));
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowNotSupportedExceptionWhenSourceFileNameContainsInvalidChars_Message()
+        {
+            if (XFS.IsUnixPlatform())
+            {
+                Assert.Pass("Path.GetInvalidChars() does not return anything on Mono");
+                return;
+            }
+
+            var destFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            foreach (var invalidChar in fileSystem.Path.GetInvalidFileNameChars().Where(x => x != fileSystem.Path.DirectorySeparatorChar))
+            {
+                var sourceFilePath = XFS.Path(@"c:\something\demo.txt") + invalidChar;
+
+                var exception =
+                    Assert.Throws<NotSupportedException>(() => fileSystem.File.Copy(sourceFilePath, destFilePath));
+
+                Assert.That(exception.Message, Is.EqualTo("The given path's format is not supported."),
+                    string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
+            }
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowNotSupportedExceptionWhenSourcePathContainsInvalidChars_Message()
+        {
+            if (XFS.IsUnixPlatform())
+            {
+                Assert.Pass("Path.GetInvalidChars() does not return anything on Mono");
+                return;
+            }
+
+            var destFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            foreach (var invalidChar in fileSystem.Path.GetInvalidPathChars())
+            {
+                var sourceFilePath = XFS.Path(@"c:\some" + invalidChar + @"thing\demo.txt");
+
+                var exception =
+                    Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(sourceFilePath, destFilePath));
+
+                Assert.That(exception.Message, Is.EqualTo("Illegal characters in path."),
+                    string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
+            }
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowNotSupportedExceptionWhenTargetPathContainsInvalidChars_Message()
+        {
+            if (XFS.IsUnixPlatform())
+            {
+                Assert.Pass("Path.GetInvalidChars() does not return anything on Mono");
+                return;
+            }
+
+            var sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            foreach (var invalidChar in fileSystem.Path.GetInvalidPathChars())
+            {
+                var destFilePath = XFS.Path(@"c:\some" + invalidChar + @"thing\demo.txt");
+
+                var exception =
+                    Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(sourceFilePath, destFilePath));
+
+                Assert.That(exception.Message, Is.EqualTo("Illegal characters in path."),
+                    string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
+            }
+        }
+        [Test]
+        public void MockFile_Copy_ShouldThrowNotSupportedExceptionWhenTargetFileNameContainsInvalidChars_Message()
+        {
+            if (XFS.IsUnixPlatform())
+            {
+                Assert.Pass("Path.GetInvalidChars() does not return anything on Mono");
+                return;
+            }
+
+            var sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            foreach (var invalidChar in fileSystem.Path.GetInvalidFileNameChars().Where(x => x != fileSystem.Path.DirectorySeparatorChar))
+            {
+                var destFilePath = XFS.Path(@"c:\something\demo.txt") + invalidChar;
+
+                var exception =
+                    Assert.Throws<NotSupportedException>(() => fileSystem.File.Copy(sourceFilePath, destFilePath));
+
+                Assert.That(exception.Message, Is.EqualTo("The given path's format is not supported."),
+                    string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
+            }
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowArgumentExceptionWhenSourceIsEmpty_Message()
+        {
+            string destFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(string.Empty, destFilePath));
+
+            Assert.That(exception.Message, Is.StringStarting("Empty file name is not legal."));
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowArgumentExceptionWhenSourceIsEmpty_ParamName()
+        {
+            string destFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(string.Empty, destFilePath));
+
+            Assert.That(exception.ParamName, Is.EqualTo("sourceFileName"));
+        }
+        [Test]
+        public void MockFile_Copy_ShouldThrowArgumentExceptionWhenSourceIsStringOfBlanks()
+        {
+            string sourceFilePath = "   ";
+            string destFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(sourceFilePath, destFilePath));
+
+            Assert.That(exception.Message, Is.EqualTo("The path is not of a legal form."));
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowArgumentNullExceptionWhenTargetIsNull_Message()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => fileSystem.File.Copy(sourceFilePath, null));
+
+            Assert.That(exception.Message, Is.StringStarting("File name cannot be null."));
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowArgumentNullExceptionWhenTargetIsNull_ParamName()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => fileSystem.File.Copy(sourceFilePath, null));
+
+            Assert.That(exception.ParamName, Is.EqualTo("destFileName"));
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowArgumentExceptionWhenTargetIsStringOfBlanks()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            string destFilePath = "   ";
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(sourceFilePath, destFilePath));
+
+            Assert.That(exception.Message, Is.EqualTo("The path is not of a legal form."));
+        }
+
+        [Test]
+        public void MockFile_Copy_ShouldThrowArgumentExceptionWhenTargetIsEmpty_Message()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(sourceFilePath, string.Empty));
+
+            Assert.That(exception.Message, Is.StringStarting("Empty file name is not legal."));
+        }
+
+        [Test]
         public void MockFile_Delete_ShouldRemoveFileFromFileSystem()
         {
             string fullPath = XFS.Path(@"c:\something\demo.txt");

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -217,13 +217,26 @@ namespace System.IO.Abstractions.TestingHelpers
         [DebuggerNonUserCode]
         private void ValidateParameter(string value, string paramName) {
             if (value == null)
-                throw new ArgumentNullException(paramName, "Value can not be null.");
+                throw new ArgumentNullException(paramName, "File name cannot be null.");
             if (value == string.Empty)
-                throw new ArgumentException("An empty file name is invalid.", paramName);
+                throw new ArgumentException("Empty file name is not legal.", paramName);
             if (value.Trim() == "")
-                throw new ArgumentException("The path has an invalid format.");
-            if (value.IndexOfAny(mockPath.GetInvalidPathChars()) > -1)
-                throw new ArgumentException("Illegal characters in path.", paramName);
+                throw new ArgumentException("The path is not of a legal form.");
+            if (ExtractFileName(value).IndexOfAny(mockPath.GetInvalidFileNameChars()) > -1)
+                throw new NotSupportedException("The given path's format is not supported.");
+            if (ExtractFilePath(value).IndexOfAny(mockPath.GetInvalidPathChars()) > -1)
+                throw new ArgumentException("Illegal characters in path.");
+        }
+
+        private string ExtractFilePath(string fullFileName)
+        {
+            var extractFilePath = fullFileName.Split(mockPath.DirectorySeparatorChar);
+            return string.Join(mockPath.DirectorySeparatorChar.ToString(), extractFilePath.Take(extractFilePath.Length - 1));
+        }
+
+        private string ExtractFileName(string fullFileName)
+        {
+            return fullFileName.Split(mockPath.DirectorySeparatorChar).Last();
         }
 
         public override Stream Open(string path, FileMode mode)

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -80,6 +80,9 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override void Copy(string sourceFileName, string destFileName, bool overwrite)
         {
+            ValidateParameter(sourceFileName, "sourceFileName");
+            ValidateParameter(destFileName, "destFileName");
+
             var directoryNameOfDestination = mockPath.GetDirectoryName(destFileName);
             if (!mockFileDataAccessor.Directory.Exists(directoryNameOfDestination))
             {


### PR DESCRIPTION
I wanted to match the thrown exceptions by System.IO.Abstractions to exceptions thrown by System.IO.

So I changed some ErrorMessages and one ExceptionType. I also added tests for File.Copy