### PR TITLE
Fixed #83 - Changed stream flushing to not re-add the file if it doesn't exist.

### DIFF
--- a/TestHelpers.Tests/MockFileDeleteTests.cs
+++ b/TestHelpers.Tests/MockFileDeleteTests.cs
@@ -1,0 +1,23 @@
+﻿namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using NUnit.Framework;
+
+    public class MockFileDeleteTests
+    {
+        [Test]
+        public void MockFile_Delete_ShouldDeleteFile()
+        {
+            var fileSystem = new MockFileSystem();
+            var path = "C:\\test";
+            var directory = fileSystem.Path.GetDirectoryName(path);
+            fileSystem.AddFile(path, new MockFileData("Bla"));
+
+            var fileCount1 = fileSystem.Directory.GetFiles(directory, "*").Length;
+            fileSystem.File.Delete(path);
+            var fileCount2 = fileSystem.Directory.GetFiles(directory, "*").Length;
+
+            Assert.AreEqual(1, fileCount1, "File should have existed");
+            Assert.AreEqual(0, fileCount2, "File should have been deleted");
+        }
+    }
+}

--- a/TestHelpers.Tests/MockFileDeleteTests.cs
+++ b/TestHelpers.Tests/MockFileDeleteTests.cs
@@ -2,13 +2,15 @@
 {
     using NUnit.Framework;
 
+    using XFS = MockUnixSupport;
+
     public class MockFileDeleteTests
     {
         [Test]
         public void MockFile_Delete_ShouldDeleteFile()
         {
             var fileSystem = new MockFileSystem();
-            var path = "C:\\test";
+            var path = XFS.Path("C:\\test");
             var directory = fileSystem.Path.GetDirectoryName(path);
             fileSystem.AddFile(path, new MockFileData("Bla"));
 

--- a/TestHelpers.Tests/MockFileStreamTests.cs
+++ b/TestHelpers.Tests/MockFileStreamTests.cs
@@ -22,5 +22,25 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Assert
             CollectionAssert.AreEqual(new byte[]{255}, filesystem.GetFile(filepath).Contents);
         }
+
+        [Test]
+        public void MockFileStream_Dispose_ShouldNotResurrectFile()
+        {
+            var fileSystem = new MockFileSystem();
+            var path = "C:\\test";
+            var directory = fileSystem.Path.GetDirectoryName(path);
+            fileSystem.AddFile(path, new MockFileData("Bla"));
+            var stream = fileSystem.File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.Delete);
+
+            var fileCount1 = fileSystem.Directory.GetFiles(directory, "*").Length;
+            fileSystem.File.Delete(path);
+            var fileCount2 = fileSystem.Directory.GetFiles(directory, "*").Length;
+            stream.Dispose();
+            var fileCount3 = fileSystem.Directory.GetFiles(directory, "*").Length;
+
+            Assert.AreEqual(1, fileCount1, "File should have existed");
+            Assert.AreEqual(0, fileCount2, "File should have been deleted");
+            Assert.AreEqual(0, fileCount3, "Disposing stream should not have resurrected the file");
+        }
     }
 }

--- a/TestHelpers.Tests/MockFileStreamTests.cs
+++ b/TestHelpers.Tests/MockFileStreamTests.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Generic;
-
-using NUnit.Framework;
-
-namespace System.IO.Abstractions.TestingHelpers.Tests
+﻿namespace System.IO.Abstractions.TestingHelpers.Tests
 {
+    using System.Collections.Generic;
+
+    using NUnit.Framework;
+
+    using XFS = MockUnixSupport;
+
     [TestFixture]
     public class MockFileStreamTests
     {
@@ -11,7 +13,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         public void MockFileStream_Flush_WritesByteToFile()
         {
             // Arrange
-            const string filepath = @"c:\something\foo.txt";
+            var filepath = XFS.Path(@"c:\something\foo.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
             var cut = new MockFileStream(filesystem, filepath);
 
@@ -27,7 +29,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         public void MockFileStream_Dispose_ShouldNotResurrectFile()
         {
             var fileSystem = new MockFileSystem();
-            var path = "C:\\test";
+            var path = XFS.Path("C:\\test");
             var directory = fileSystem.Path.GetDirectoryName(path);
             fileSystem.AddFile(path, new MockFileData("Bla"));
             var stream = fileSystem.File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.Delete);

--- a/TestHelpers.Tests/TestHelpers.Tests.csproj
+++ b/TestHelpers.Tests/TestHelpers.Tests.csproj
@@ -80,6 +80,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MockFileDeleteTests.cs" />
     <Compile Include="FileSystemTests.cs" />
     <Compile Include="MockDirectoryInfoTests.cs" />
     <Compile Include="MockDirectoryTests.cs" />

--- a/TestingHelpers/MockFileStream.cs
+++ b/TestingHelpers/MockFileStream.cs
@@ -23,6 +23,10 @@
                         : SeekOrigin.Begin);
                 }
             }
+            else
+            {
+                mockFileDataAccessor.AddFile(path, new MockFileData(""));
+            }
         }
 
         public override void Close() 
@@ -38,15 +42,17 @@
         private void InternalFlush()
         {
             if (mockFileDataAccessor.FileExists(path))
+            {
                 mockFileDataAccessor.RemoveFile(path);
 
-            /* reset back to the beginning .. */
-            base.Seek(0, SeekOrigin.Begin);
-            /* .. read everything out */
-            var data = new byte[base.Length];
-            base.Read(data, 0, (int)base.Length);
-            /* .. put it in the mock system */
-            mockFileDataAccessor.AddFile(path, new MockFileData(data));
+                /* reset back to the beginning .. */
+                base.Seek(0, SeekOrigin.Begin);
+                /* .. read everything out */
+                var data = new byte[base.Length];
+                base.Read(data, 0, (int)base.Length);
+                /* .. put it in the mock system */
+                mockFileDataAccessor.AddFile(path, new MockFileData(data));
+            }
         }
     }
 }


### PR DESCRIPTION
We added 2 tests. A simple file delete test and a stream flush test.