### PR TITLE
Implemented EnumerateFiles methods

### DIFF
--- a/TestHelpers.Tests/StringExtensionsTests.cs
+++ b/TestHelpers.Tests/StringExtensionsTests.cs
@@ -58,5 +58,16 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(result, Is.EquivalentTo(expected));
         }
 
+        [TestCase("*", Result = @"^.*$")]
+        [TestCase("nowildcard.txt", Result = @"^nowildcard\.txt$")]
+        [TestCase("*.txt", Result = @"^.*\.txt.*$")]
+        [TestCase("test?.txt", Result = @"^test.\.txt$")]
+        [TestCase("*.so", Result = @"^.*\.so$")]
+        [TestCase("*.abcd", Result = @"^.*\.abcd$")]
+        public string WildcardToRegex(string wildcard)
+        {
+            return wildcard.WildcardToRegex();
+        }
+
     }
 }

--- a/TestingHelpers/StringExtensions.cs
+++ b/TestingHelpers/StringExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace System.IO.Abstractions.TestingHelpers
 {
@@ -19,6 +20,30 @@ namespace System.IO.Abstractions.TestingHelpers
             }
 
             return list.ToArray();
+        }
+
+        // from http://www.codeproject.com/Articles/11556/Converting-Wildcards-to-Regexes
+        // with some adaptions to match the rules on
+        // https://msdn.microsoft.com/en-us/library/ms143327%28v=vs.110%29.aspx
+        internal static string WildcardToRegex(this string pattern)
+        {
+            var appendExtensionWildcard = false;
+
+            if (pattern.Contains("*"))
+            {
+                // bla.txt => .txt
+                var extension = Path.GetExtension(pattern);
+                if (extension.Length == 4)
+                {
+                    appendExtensionWildcard = true;
+                }
+            }
+
+            return "^" + Regex.Escape(pattern)
+                              .Replace(@"\*", ".*")
+                              .Replace(@"\?", ".")
+                       + (appendExtensionWildcard ? ".*" : "") 
+                       + "$";
         }
 
         [Pure]


### PR DESCRIPTION
The search pattern respects Microsofts [notes](https://msdn.microsoft.com/en-us/library/ms143327%28v=vs.110%29.aspx).

Initially, I also wanted to redirect the existing `MockDirectoryInfo#GetFiles(...)` methods to the new `EnumerateFiles(...)` methods. But as I don't fully understand the currently used 
[`GetFilesInternal`](https://github.com/tathamoddie/System.IO.Abstractions/blob/71c432a1b06be7153532293799012a68b038bf45/TestingHelpers/MockDirectory.cs#L171-L198) method, I'm first waiting for your feedback.
