### PR TITLE
MockFileSystem.FileExists should not check directories

### DIFF
--- a/TestingHelpers/MockFileSystem.cs
+++ b/TestingHelpers/MockFileSystem.cs
@@ -162,7 +162,7 @@ namespace System.IO.Abstractions.TestingHelpers
             path = FixPath(path);
 
             lock (files)
-                return files.ContainsKey(path);
+                return files.ContainsKey(path) && !files[path].IsDirectory;
         }
 
         public IEnumerable<string> AllPaths


### PR DESCRIPTION
Currently you can call `FileExists` with a directory that might exist in the mock file system and the method will return `true`, which is incorrect behavior. This fix updates the mock file system so it will only say a file exists if it's _actually a file_.