### PR TITLE
Mock File.Exists and Directory.Exists only work on respective entities

### DIFF
--- a/TestHelpers.Tests/MockDirectoryTests.cs
+++ b/TestHelpers.Tests/MockDirectoryTests.cs
@@ -393,6 +393,20 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockDirectory_Exists_ShouldReturnFalseForFiles()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(XFS.Path(@"c:\foo\bar.txt"), new MockFileData("Demo text content"));
+
+            // Act
+            var result = fileSystem.Directory.Exists(XFS.Path(@"c:\foo\bar.txt"));
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
         public void MockDirectory_CreateDirectory_ShouldCreateFolderInMemoryFileSystem()
         {
             // Arrange

--- a/TestHelpers.Tests/MockFileExistsTests.cs
+++ b/TestHelpers.Tests/MockFileExistsTests.cs
@@ -71,5 +71,24 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.That(file.Exists(null), Is.False);
         }
+
+        [Test]
+        public void MockFile_Exists_ShouldReturnFalseForDirectories()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\something\demo.txt"), new MockFileData("Demo text content") },
+                { XFS.Path(@"c:\something\other.gif"), new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+            });
+
+            var file = new MockFile(fileSystem);
+
+            // Act
+            var result = file.Exists(XFS.Path(@"c:\SomeThing\"));
+
+            // Assert
+            Assert.IsFalse(result);
+        }
     }
 }

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -149,7 +149,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override bool Exists(string path)
         {
-            return mockFileDataAccessor.FileExists(path);
+            return mockFileDataAccessor.FileExists(path) && !mockFileDataAccessor.AllDirectories.Any(d => d.Equals(path, StringComparison.OrdinalIgnoreCase));
         }
 
         public override FileSecurity GetAccessControl(string path)

--- a/TestingHelpers/MockFileSystem.cs
+++ b/TestingHelpers/MockFileSystem.cs
@@ -162,7 +162,7 @@ namespace System.IO.Abstractions.TestingHelpers
             path = FixPath(path);
 
             lock (files)
-                return files.ContainsKey(path);
+                return files.ContainsKey(path) && !files[path].IsDirectory;
         }
 
         public IEnumerable<string> AllPaths

--- a/TestingHelpers/MockFileSystem.cs
+++ b/TestingHelpers/MockFileSystem.cs
@@ -162,7 +162,7 @@ namespace System.IO.Abstractions.TestingHelpers
             path = FixPath(path);
 
             lock (files)
-                return files.ContainsKey(path) && !files[path].IsDirectory;
+                return files.ContainsKey(path);
         }
 
         public IEnumerable<string> AllPaths


### PR DESCRIPTION
The File.Exists operation in the mock file system currently returns true for directories. This update makes it so File.Exists on a directory that exists will return false; Directory.Exists will also only work on directories rather than files.

The Directory.Exists behavior was correct to begin with but there weren't any tests to verify that so I added a test for it. File.Exists was wrong, so I fixed it in what I hope is the appropriate way.