### PR TITLE
Implement the ReadLines methods on MockFile

### DIFF
--- a/TestHelpers.Tests/MockFileReadLinesTests.cs
+++ b/TestHelpers.Tests/MockFileReadLinesTests.cs
@@ -1,0 +1,55 @@
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using Collections.Generic;
+
+    using NUnit.Framework;
+
+    using Text;
+
+    using XFS = MockUnixSupport;
+
+    public class MockFileReadLinesTests {
+        [Test]
+        public void MockFile_ReadLines_ShouldReturnOriginalTextData()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\something\demo.txt"), new MockFileData("Demo\r\ntext\ncontent\rvalue") },
+                { XFS.Path(@"c:\something\other.gif"), new MockFileData(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }) }
+            });
+
+            var file = new MockFile(fileSystem);
+
+            // Act
+            var result = file.ReadLines(XFS.Path(@"c:\something\demo.txt"));
+
+            // Assert
+            CollectionAssert.AreEqual(
+                new[] { "Demo", "text", "content", "value" },
+                result);
+        }
+
+        [Test]
+        public void MockFile_ReadLines_ShouldReturnOriginalDataWithCustomEncoding()
+        {
+            // Arrange
+            string text = "Hello\r\nthere\rBob\nBob!";
+            var encodedText = Encoding.BigEndianUnicode.GetBytes(text);
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\something\demo.txt"), new MockFileData(encodedText) }
+            });
+
+            var file = new MockFile(fileSystem);
+
+            // Act
+            var result = file.ReadLines(XFS.Path(@"c:\something\demo.txt"), Encoding.BigEndianUnicode);
+
+            // Assert
+            CollectionAssert.AreEqual(
+                new [] { "Hello", "there", "Bob", "Bob!" },
+                result);
+        }
+    }
+}

--- a/TestHelpers.Tests/TestHelpers.Tests.csproj
+++ b/TestHelpers.Tests/TestHelpers.Tests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="MockFileMoveTests.cs" />
     <Compile Include="MockFileOpenTests.cs" />
     <Compile Include="MockFileReadAllLinesTests.cs" />
+    <Compile Include="MockFileReadLinesTests.cs" />
     <Compile Include="MockFileStreamTests.cs" />
     <Compile Include="MockFileSystemTests.cs" />
     <Compile Include="MockFileTests.cs" />

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -360,12 +360,12 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override IEnumerable<string> ReadLines(string path)
         {
-            throw new NotImplementedException();
+            return ReadAllLines(path);
         }
 
         public override IEnumerable<string> ReadLines(string path, Encoding encoding)
         {
-            throw new NotImplementedException();
+            return ReadAllLines(path, encoding);
         }
 
         public override void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName)


### PR DESCRIPTION
These methods needed to have the same behavior as the ReadAllLines methods. Tests are included.