### PR TITLE
Fixed #136

### DIFF
--- a/TestHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/TestHelpers.Tests/MockDirectoryInfoTests.cs
@@ -134,7 +134,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             });
 
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\temp\folder"));
-            var result = directoryInfo.EnumerateFileSystemInfos("f*").ToArray();
+            var result = directoryInfo.EnumerateFileSystemInfos("f*", SearchOption.AllDirectories).ToArray();
 
             Assert.That(result.Length, Is.EqualTo(2));
         }

--- a/TestingHelpers/MockDirectoryInfo.cs
+++ b/TestingHelpers/MockDirectoryInfo.cs
@@ -186,7 +186,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override IEnumerable<FileSystemInfoBase> EnumerateFileSystemInfos(string searchPattern, SearchOption searchOption)
         {
-            return GetDirectories(searchPattern, searchOption);
+            return GetFileSystemInfos(searchPattern, searchOption);
         }
 
         public override DirectorySecurity GetAccessControl()


### PR DESCRIPTION
 - Problem was simply "EnumerateFileSystemInfos(string searchPattern, SearchOption searchOption)" calling out to GetDirectories instead of GetFileSystemInfos
 - Modified a test to call this method (and fail). Test passes with this fix

Signed-off-by: Martin Evans <martindevans@gmail.com>