### PR TITLE
Fix MockFileInfo reset own path on MoveTo to match functionality for …

### DIFF
--- a/TestHelpers.Tests/MockFileInfoTests.cs
+++ b/TestHelpers.Tests/MockFileInfoTests.cs
@@ -458,5 +458,23 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.AreEqual(@"line 1\r\nline 2", result);
         }
+
+        [Test]
+        public void MockFileInfo_MoveTo_ShouldUpdateFileInfoDirectoryAndFullName()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(XFS.Path(@"c:\temp\file.txt"), new MockFileData(@"line 1\r\nline 2"));
+            var fileInfo = fileSystem.FileInfo.FromFileName(XFS.Path(@"c:\temp\file.txt"));
+
+            // Act
+            string destinationFolder = XFS.Path(@"c:\temp2");
+            string destination = XFS.Path(destinationFolder + @"\file.txt");
+            fileSystem.AddDirectory(destination);
+            fileInfo.MoveTo(destination);
+
+            Assert.AreEqual(fileInfo.DirectoryName, destinationFolder);
+            Assert.AreEqual(fileInfo.FullName, destination);
+        }
     }
 }

--- a/TestingHelpers/MockFileInfo.cs
+++ b/TestingHelpers/MockFileInfo.cs
@@ -6,7 +6,7 @@ namespace System.IO.Abstractions.TestingHelpers
     public class MockFileInfo : FileInfoBase
     {
         private readonly IMockFileDataAccessor mockFileSystem;
-        private readonly string path;
+        private string path;
 
         public MockFileInfo(IMockFileDataAccessor mockFileSystem, string path)
         {
@@ -209,8 +209,9 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override void MoveTo(string destFileName)
         {
-            CopyTo(destFileName);
+            var movedFileInfo = CopyTo(destFileName);
             Delete();
+            path = movedFileInfo.FullName;
         }
 
         public override Stream Open(FileMode mode)


### PR DESCRIPTION
…FileInfo with Windows filesystem (not sure whether this reflects functionality for Unix/Linux filesystem).