### PR TITLE
Fixed MockFile to properly use DirectoryNotFoundException

### DIFF
--- a/TestHelpers.Tests/MockFileMoveTests.cs
+++ b/TestHelpers.Tests/MockFileMoveTests.cs
@@ -283,12 +283,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 {sourceFilePath, new MockFileData(new byte[] {0})}
             });
 
-            //var exists = fileSystem.Directory.Exists(XFS.Path(@"c:\something"));
-            //exists = fileSystem.Directory.Exists(XFS.Path(@"c:\something22"));
-
-            var exception = Assert.Throws<DirectoryNotFoundException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
-            //Message = "Could not find a part of the path."
-            Assert.That(exception.Message, Is.EqualTo(XFS.Path(@"Could not find a part of the path.")));
+            Assert.That(() => fileSystem.File.Move(sourceFilePath, destFilePath),
+                Throws.InstanceOf<DirectoryNotFoundException>().With.Message.StartsWith(@"Could not find a part of the path"));
         }
     }
 }

--- a/TestHelpers.Tests/MockFileTests.cs
+++ b/TestHelpers.Tests/MockFileTests.cs
@@ -433,6 +433,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             string path = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
             var fileContent = new byte[] { 1, 2, 3, 4 };
+            fileSystem.AddDirectory(@"c:\something");
 
             // Act
             fileSystem.File.WriteAllBytes(path, fileContent);

--- a/TestHelpers.Tests/MockFileWriteAllBytesTests.cs
+++ b/TestHelpers.Tests/MockFileWriteAllBytesTests.cs
@@ -8,12 +8,28 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockFileWriteAllBytesTests
     {
         [Test]
+        public void MockFile_WriteAllBytes_ShouldThrowDirectoryNotFoundExceptionIfPathDoesNotExists()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            string path = XFS.Path(@"c:\something\file.txt");
+            var fileContent = new byte[] { 1, 2, 3, 4 };
+
+            // Act
+            TestDelegate action = () => fileSystem.File.WriteAllBytes(path, fileContent);
+
+            // Assert
+            Assert.Throws<DirectoryNotFoundException>(action);
+        }
+
+        [Test]
         public void MockFile_WriteAllBytes_ShouldWriteDataToMemoryFileSystem()
         {
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
             var fileContent = new byte[] { 1, 2, 3, 4 };
+            fileSystem.AddDirectory(@"c:\something");
 
             // Act
             fileSystem.File.WriteAllBytes(path, fileContent);

--- a/TestHelpers.Tests/MockFileWriteAllLinesTests.cs
+++ b/TestHelpers.Tests/MockFileWriteAllLinesTests.cs
@@ -18,6 +18,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 get
                 {
                     var fileSystem = new MockFileSystem();
+                    fileSystem.AddDirectory(@"c:\something");
                     var fileContentEnumerable = new List<string> { "first line", "second line", "third line", "fourth and last line" };
                     var fileContentArray = fileContentEnumerable.ToArray();
                     Action writeEnumberable = () => fileSystem.File.WriteAllLines(Path, fileContentEnumerable);
@@ -168,6 +169,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                     var path = XFS.Path(@"c:\something\file.txt");
                     var mockFileData = new MockFileData(string.Empty);
                     mockFileData.Attributes = FileAttributes.ReadOnly;
+                    fileSystem.AddDirectory(@"c:\something");
                     fileSystem.AddFile(path, mockFileData);
                     List<string> fileContentEnumerable = null;
                     string[] fileContentArray = null;

--- a/TestHelpers.Tests/MockFileWriteAllTextTests.cs
+++ b/TestHelpers.Tests/MockFileWriteAllTextTests.cs
@@ -16,6 +16,7 @@
             string path = XFS.Path(@"c:\something\demo.txt");
             string fileContent = "Hello there!";
             var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(@"c:\something");
 
             // Act
             fileSystem.File.WriteAllText(path, fileContent);
@@ -34,6 +35,7 @@
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(@"c:\something");
 
             // Act
             fileSystem.File.WriteAllText(path, "foo");
@@ -124,6 +126,20 @@
             Assert.Throws<UnauthorizedAccessException>(action);
         }
 
+        [Test]
+        public void MockFile_WriteAllText_ShouldThrowDirectoryNotFoundExceptionIfPathDoesNotExists()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            string path = XFS.Path(@"c:\something\file.txt");
+          
+            // Act
+            TestDelegate action = () => fileSystem.File.WriteAllText(path, string.Empty);
+
+            // Assert
+            Assert.Throws<DirectoryNotFoundException>(action);
+        }
+
         private IEnumerable<KeyValuePair<Encoding, byte[]>> GetEncodingsWithExpectedBytes()
         {
             Encoding utf8WithoutBom = new UTF8Encoding(false, true);
@@ -175,6 +191,7 @@
             byte[] expectedBytes = encodingsWithContents.Value;
             Encoding encoding = encodingsWithContents.Key;
             var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(@"c:\something");
 
             // Act
             fileSystem.File.WriteAllText(path, FileContent, encoding);
@@ -194,6 +211,7 @@
             var expected = "Hello there!" + Environment.NewLine + "Second line!" + Environment.NewLine;
 
             var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(@"c:\something");
 
             // Act
             fileSystem.File.WriteAllLines(path, fileContent);

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -593,10 +593,12 @@ namespace System.IO.Abstractions.TestingHelpers
 
             VerifyValueIsNotNull(bytes, "bytes");
 
+            VerifyDirectoryExists(path);
+
             mockFileDataAccessor.AddFile(path, new MockFileData(bytes));
         }
 
-        /// <summary>
+       /// <summary>
         /// Creates a new file, writes a collection of strings to the file, and then closes the file.
         /// </summary>
         /// <param name="path">The file to write to.</param>
@@ -859,12 +861,8 @@ namespace System.IO.Abstractions.TestingHelpers
             {
                 throw new UnauthorizedAccessException(string.Format(CultureInfo.InvariantCulture, Properties.Resources.ACCESS_TO_THE_PATH_IS_DENIED, path));
             }
-            
-            var destDir = mockFileDataAccessor.Directory.GetParent(path);
-            if (!destDir.Exists)
-            {
-                throw new DirectoryNotFoundException(string.Format("Could not find a part of the path '{0}'.", destDir));
-            }
+
+            VerifyDirectoryExists(path);
      
             MockFileData data = contents == null ? new MockFileData(new byte[0]) : new MockFileData(contents, encoding);
             mockFileDataAccessor.AddFile(path, data);
@@ -890,6 +888,15 @@ namespace System.IO.Abstractions.TestingHelpers
             if (value == null)
             {
                 throw new ArgumentNullException(parameterName, Properties.Resources.VALUE_CANNOT_BE_NULL);
+            }
+        }
+
+        private void VerifyDirectoryExists(string path)
+        {
+            var destDir = mockFileDataAccessor.Directory.GetParent(path);
+            if (!destDir.Exists)
+            {
+                throw new DirectoryNotFoundException(string.Format("Could not find a part of the path '{0}'.", destDir));
             }
         }
     }

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -241,12 +241,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 }
                 else
                 {
-                    var parentDirectoryInfo = directoryInfo.Parent;
-                    if (!parentDirectoryInfo.Exists)
-                    {
-                        throw new DirectoryNotFoundException(string.Format(CultureInfo.InvariantCulture,
-                            Properties.Resources.COULD_NOT_FIND_PART_OF_PATH_EXCEPTION, path));
-                    }
+                    VerifyDirectoryExists(path);
 
                     throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, "Could not find file '{0}'.", path));
                 }
@@ -335,11 +330,7 @@ namespace System.IO.Abstractions.TestingHelpers
             if (sourceFile == null)
                 throw new FileNotFoundException(string.Format(CultureInfo.InvariantCulture, "The file \"{0}\" could not be found.", sourceFileName), sourceFileName);
 
-            var destDir = mockFileDataAccessor.Directory.GetParent(destFileName);
-            if (!destDir.Exists)
-            {
-                throw new DirectoryNotFoundException("Could not find a part of the path.");
-            }
+            VerifyDirectoryExists(destFileName);
 
             mockFileDataAccessor.AddFile(destFileName, new MockFileData(sourceFile.Contents));
             mockFileDataAccessor.RemoveFile(sourceFileName);
@@ -893,10 +884,10 @@ namespace System.IO.Abstractions.TestingHelpers
 
         private void VerifyDirectoryExists(string path)
         {
-            var destDir = mockFileDataAccessor.Directory.GetParent(path);
-            if (!destDir.Exists)
+            DirectoryInfoBase dir = mockFileDataAccessor.Directory.GetParent(path);
+            if (!dir.Exists)
             {
-                throw new DirectoryNotFoundException(string.Format("Could not find a part of the path '{0}'.", destDir));
+                throw new DirectoryNotFoundException(string.Format(CultureInfo.InvariantCulture, Properties.Resources.COULD_NOT_FIND_PART_OF_PATH_EXCEPTION, dir));
             }
         }
     }

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -817,8 +817,6 @@ namespace System.IO.Abstractions.TestingHelpers
         /// </remarks>
         public override void WriteAllText(string path, string contents)
         {
-            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
-
             WriteAllText(path, contents, MockFileData.DefaultEncoding);
         }
 
@@ -861,7 +859,13 @@ namespace System.IO.Abstractions.TestingHelpers
             {
                 throw new UnauthorizedAccessException(string.Format(CultureInfo.InvariantCulture, Properties.Resources.ACCESS_TO_THE_PATH_IS_DENIED, path));
             }
-
+            
+            var destDir = mockFileDataAccessor.Directory.GetParent(path);
+            if (!destDir.Exists)
+            {
+                throw new DirectoryNotFoundException(string.Format("Could not find a part of the path '{0}'.", destDir));
+            }
+     
             MockFileData data = contents == null ? new MockFileData(new byte[0]) : new MockFileData(contents, encoding);
             mockFileDataAccessor.AddFile(path, data);
         }


### PR DESCRIPTION
`MockFile` uses `AddFile()` which implicitly creates directories.
Added checks for existing directories to throw `DirectoryNotFoundException` accordingly.

Similar to [PullRequest#140](https://github.com/tathamoddie/System.IO.Abstractions/pull/140), but without changing the behavior of `AddFile()`.