### PR TITLE
Issue #170: Opening a MockFileStream to read from a nonexistent file will throw an exception.

### DIFF
--- a/TestHelpers.Tests/MockFileStreamTests.cs
+++ b/TestHelpers.Tests/MockFileStreamTests.cs
@@ -15,7 +15,7 @@
             // Arrange
             var filepath = XFS.Path(@"c:\something\foo.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
-            var cut = new MockFileStream(filesystem, filepath);
+            var cut = new MockFileStream(filesystem, filepath, MockFileStream.StreamType.WRITE);
 
             // Act
             cut.WriteByte(255);
@@ -43,6 +43,20 @@
             Assert.AreEqual(1, fileCount1, "File should have existed");
             Assert.AreEqual(0, fileCount2, "File should have been deleted");
             Assert.AreEqual(0, fileCount3, "Disposing stream should not have resurrected the file");
+        }
+
+        [Test]
+        [ExpectedException(typeof(FileNotFoundException))]
+        public void MockFileStream_Constructor_Reading_Nonexistent_File_Throws_Exception()
+        {
+            // Arrange
+            var nonexistentFilePath = XFS.Path(@"c:\something\foo.txt");
+            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());         
+
+            // Act
+            var illegalFileStream = new MockFileStream(filesystem, nonexistentFilePath, MockFileStream.StreamType.READ);
+
+            // Assert - expect an exception
         }
     }
 }

--- a/TestingHelpers/MockFile.cs
+++ b/TestingHelpers/MockFile.cs
@@ -399,7 +399,7 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
 
-            return new MockFileStream(mockFileDataAccessor, path);
+            return new MockFileStream(mockFileDataAccessor, path, MockFileStream.StreamType.WRITE);
         }
 
         public override byte[] ReadAllBytes(string path)

--- a/TestingHelpers/MockFileInfo.cs
+++ b/TestingHelpers/MockFileInfo.cs
@@ -155,7 +155,7 @@ namespace System.IO.Abstractions.TestingHelpers
         public override StreamWriter AppendText()
         {
             if (MockFileData == null) throw new FileNotFoundException("File not found", path);
-            return new StreamWriter(new MockFileStream(mockFileSystem, FullName, true));
+            return new StreamWriter(new MockFileStream(mockFileSystem, FullName, MockFileStream.StreamType.APPEND));
             //return ((MockFileDataModifier) MockFileData).AppendText();
         }
 
@@ -231,7 +231,8 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override Stream OpenRead()
         {
-            return new MockFileStream(mockFileSystem, path);
+            if (MockFileData == null) throw new FileNotFoundException("File not found", path);
+            return new MockFileStream(mockFileSystem, path, MockFileStream.StreamType.READ);
         }
 
         public override StreamReader OpenText()
@@ -241,7 +242,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override Stream OpenWrite()
         {
-            return new MockFileStream(mockFileSystem, path);
+            return new MockFileStream(mockFileSystem, path, MockFileStream.StreamType.WRITE);
         }
 
         public override FileInfoBase Replace(string destinationFileName, string destinationBackupFileName)

--- a/TestingHelpers/MockFileStream.cs
+++ b/TestingHelpers/MockFileStream.cs
@@ -6,7 +6,14 @@
         private readonly IMockFileDataAccessor mockFileDataAccessor;
         private readonly string path;
 
-        public MockFileStream(IMockFileDataAccessor mockFileDataAccessor, string path, bool forAppend = false)
+        public enum StreamType
+        {
+            READ,
+            WRITE,
+            APPEND
+        }
+
+        public MockFileStream(IMockFileDataAccessor mockFileDataAccessor, string path, StreamType streamType)
         {
             if (mockFileDataAccessor == null)
             {
@@ -23,13 +30,17 @@
                 if (data != null && data.Length > 0)
                 {
                     Write(data, 0, data.Length);
-                    Seek(0, forAppend
+                    Seek(0, StreamType.APPEND.Equals(streamType)
                         ? SeekOrigin.End
                         : SeekOrigin.Begin);
                 }
             }
             else
             {
+                if (StreamType.READ.Equals(streamType))
+                {
+                    throw new FileNotFoundException("File not found.", path);
+                }
                 mockFileDataAccessor.AddFile(path, new MockFileData(new byte[] { }));
             }
         }


### PR DESCRIPTION
Implementation note - instead of using System.IO.FileAccess/FileMode, I
ended up creating an internal StreamType enum instead to keep the
interface simple. That's potentially something to change upon on review,
but I think it's good the way it is.