### PR TITLE
#186: Fixed difference in behavior of GetDirectories with absolute or relative paths

### DIFF
--- a/TestHelpers.Tests/MockDirectoryTests.cs
+++ b/TestHelpers.Tests/MockDirectoryTests.cs
@@ -844,6 +844,49 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockDirectory_GetDirectories_RelativeWithNoSubDirectories_ShouldReturnDirectories()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory("Folder");
+
+            // Act
+            var actualResult = fileSystem.Directory.GetDirectories("Folder");
+
+            // Assert
+            Assert.That(actualResult, Is.Empty);
+        }
+
+        [TestCase(@"Folder\SubFolder")]
+        [TestCase(@"Folder")]
+        public void MockDirectory_GetDirectories_RelativeDirectory_ShouldReturnDirectories(string relativeDirPath)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory(relativeDirPath);
+
+            // Act
+            var actualResult = fileSystem.Directory.GetDirectories(relativeDirPath);
+
+            // Assert
+            Assert.That(actualResult, Is.Empty);
+        }
+
+        [Test]
+        public void MockDirectory_GetDirectories_AbsoluteWithNoSubDirectories_ShouldReturnDirectories()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory("Folder");
+
+            // Act
+            var actualResult = fileSystem.Directory.GetDirectories(fileSystem.Path.GetFullPath("Folder"));
+
+            // Assert
+            Assert.That(actualResult, Is.Empty);
+        }
+
+        [Test]
         public void MockDirectory_GetDirectories_WithAllDirectories_ShouldReturnsAllMatchingSubFolders()
         {
             // Arrange

--- a/TestingHelpers/MockDirectory.cs
+++ b/TestingHelpers/MockDirectory.cs
@@ -178,7 +178,6 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             CheckSearchPattern(searchPattern);
             path = EnsurePathEndsWithDirectorySeparator(path);
-            path = mockFileDataAccessor.Path.GetFullPath(path);
 
             bool isUnix = XFS.IsUnixPlatform();
 
@@ -421,6 +420,7 @@ namespace System.IO.Abstractions.TestingHelpers
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
 
             path = EnsurePathEndsWithDirectorySeparator(path);
+            path = mockFileDataAccessor.Path.GetFullPath(path);
 
             if (!Exists(path))
             {


### PR DESCRIPTION
I've added tests and everything works,
but I don't know if the change I made is acceptable.
this should fix [Issue#169](https://github.com/tathamoddie/System.IO.Abstractions/issues/169)

feel free to correct me.