### PR TITLE
178 - ensuring build configuration is set to release

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,10 @@ cache:
 before_build:
 - nuget restore
 
+platform: Any CPU
+
+configuration: Release
+
 build:
   publish_nuget: true
 


### PR DESCRIPTION
I believe the reason why the System.IO.Abstractions has not been signed since moving to appveyor is because it is using the default build configuration of the csproj file which is for a debug build (check the output of appveyor and you'll see it's only creating a bin/debug folder). I think you need to specify the configuration to be release in the appveyor.yml file. Assuming the build works for this pull request and the output indicates bin/release was used then it is likely that the assembly was signed correctly.