### PR TITLE
Add support for Directory AccessControl

### DIFF
--- a/TestHelpers.Tests/MockDirectoryGetAccessControlTests.cs
+++ b/TestHelpers.Tests/MockDirectoryGetAccessControlTests.cs
@@ -1,0 +1,69 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Security.AccessControl;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using XFS = MockUnixSupport;
+
+    [TestFixture]
+    public class MockDirectoryGetAccessControlTests
+    {
+        [TestCase(" ")]
+        [TestCase("   ")]
+        public void MockDirectory_GetAccessControl_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.GetAccessControl(path);
+
+            // Assert
+            var exception = Assert.Throws<ArgumentException>(action);
+            Assert.That(exception.ParamName, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void MockDirectory_GetAccessControl_ShouldThrowDirectoryNotFoundExceptionIfDirectoryDoesNotExistInMockData()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var expectedDirectoryName = XFS.Path(@"c:\a");
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.GetAccessControl(expectedDirectoryName);
+
+            // Assert
+            Assert.Throws<DirectoryNotFoundException>(action);
+        }
+
+        [Test]
+        public void MockDirectory_GetAccessControl_ShouldReturnAccessControlOfDirectoryData()
+        {
+            // Arrange
+            var expectedDirectorySecurity = new DirectorySecurity();
+            expectedDirectorySecurity.SetAccessRuleProtection(false, false);
+
+            var filePath = XFS.Path(@"c:\a\");
+            var fileData = new MockDirectoryData()
+            {
+                AccessControl = expectedDirectorySecurity,
+            };
+
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
+            {
+                { filePath, fileData }
+            });
+
+            // Act
+            var directorySecurity = fileSystem.Directory.GetAccessControl(filePath);
+
+            // Assert
+            Assert.That(directorySecurity, Is.EqualTo(expectedDirectorySecurity));
+        }
+    }
+}

--- a/TestHelpers.Tests/MockDirectorySetAccessControlTests.cs
+++ b/TestHelpers.Tests/MockDirectorySetAccessControlTests.cs
@@ -1,0 +1,68 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using Security.AccessControl;
+    using XFS = MockUnixSupport;
+
+    [TestFixture]
+    public class MockDirectorySetAccessControlTests
+    {
+        [TestCase(" ")]
+        [TestCase("   ")]
+        public void MockDirectory_SetAccessControl_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var directorySecurity = new DirectorySecurity();
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.SetAccessControl(path, directorySecurity);
+
+            // Assert
+            var exception = Assert.Throws<ArgumentException>(action);
+            Assert.That(exception.ParamName, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void MockDirectory_SetAccessControl_ShouldThrowDirectoryNotFoundExceptionIfDirectoryDoesNotExistInMockData()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var expectedFileName = XFS.Path(@"c:\a\");
+            var directorySecurity = new DirectorySecurity();
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.SetAccessControl(expectedFileName, directorySecurity);
+
+            // Assert
+            Assert.Throws<DirectoryNotFoundException>(action);
+        }
+
+        [Test]
+        public void MockDirectory_SetAccessControl_ShouldReturnAccessControlOfDirectoryData()
+        {
+            // Arrange
+            var filePath = XFS.Path(@"c:\a\");
+            var fileData = new MockDirectoryData();
+
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
+            {
+                { filePath, fileData }
+            });
+
+            // Act
+            var expectedAccessControl = new DirectorySecurity();
+            expectedAccessControl.SetAccessRuleProtection(false, false);
+            fileSystem.Directory.SetAccessControl(filePath, expectedAccessControl);
+
+            // Assert
+            var accessControl = fileSystem.Directory.GetAccessControl(filePath);
+            Assert.That(accessControl, Is.EqualTo(expectedAccessControl));
+        }
+    }
+}

--- a/TestHelpers.Tests/MockDirectoryTests.cs
+++ b/TestHelpers.Tests/MockDirectoryTests.cs
@@ -1391,10 +1391,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             // Arrange
             var fileSystem = new MockFileSystem();
-            fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\foo"));
+            fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\foo\"));
 
             // Act
-            DirectorySecurity result = fileSystem.Directory.GetAccessControl(XFS.Path(@"c:\foo"));
+            DirectorySecurity result = fileSystem.Directory.GetAccessControl(XFS.Path(@"c:\foo\"));
 
             // Assert
             Assert.That(result, Is.Not.Null);

--- a/TestingHelpers/MockDirectory.cs
+++ b/TestingHelpers/MockDirectory.cs
@@ -32,7 +32,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override DirectoryInfoBase CreateDirectory(string path)
         {
-            return CreateDirectoryInternal(path, null);
+            return CreateDirectoryInternal(path, new DirectorySecurity());
         }
 
 #if NET40
@@ -61,6 +61,7 @@ namespace System.IO.Abstractions.TestingHelpers
             }
 
             var created = new MockDirectoryInfo(mockFileDataAccessor, path);
+            created.SetAccessControl(directorySecurity);
             return created;
         }
 
@@ -93,7 +94,6 @@ namespace System.IO.Abstractions.TestingHelpers
             try
             {
                 path = EnsurePathEndsWithDirectorySeparator(path);
-
                 path = mockFileDataAccessor.Path.GetFullPath(path);
                 return mockFileDataAccessor.AllDirectories.Any(p => p.Equals(path, StringComparison.OrdinalIgnoreCase));
             }
@@ -104,19 +104,21 @@ namespace System.IO.Abstractions.TestingHelpers
         }
 
         public override DirectorySecurity GetAccessControl(string path)
-        {
-            // First crude implementation to avoid NotImplementedException
-            if (Exists(path))
+        {           
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+            path = EnsurePathEndsWithDirectorySeparator(path);
+            
+            if (!mockFileDataAccessor.Directory.Exists(path))
             {
-                return new DirectorySecurity();
+                throw new DirectoryNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"), path));
             }
 
-            throw new DirectoryNotFoundException(path);
+            var directoryData = (MockDirectoryData) mockFileDataAccessor.GetFile(path);
+            return directoryData.AccessControl;
         }
 
         public override DirectorySecurity GetAccessControl(string path, AccessControlSections includeSections)
         {
-            // First crude implementation to avoid NotImplementedException
             return GetAccessControl(path);
         }
 
@@ -376,7 +378,16 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public override void SetAccessControl(string path, DirectorySecurity directorySecurity)
         {
-            throw new NotImplementedException(StringResources.Manager.GetString("NOT_IMPLEMENTED_EXCEPTION"));
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+            path = EnsurePathEndsWithDirectorySeparator(path);
+
+            if (!mockFileDataAccessor.Directory.Exists(path))
+            {
+                throw new DirectoryNotFoundException(string.Format(CultureInfo.InvariantCulture, StringResources.Manager.GetString("COULD_NOT_FIND_PART_OF_PATH_EXCEPTION"), path));
+            }
+
+            var directoryData = (MockDirectoryData)mockFileDataAccessor.GetFile(path);
+            directoryData.AccessControl = directorySecurity;
         }
 
         public override void SetCreationTime(string path, DateTime creationTime)

--- a/TestingHelpers/MockDirectoryData.cs
+++ b/TestingHelpers/MockDirectoryData.cs
@@ -1,13 +1,24 @@
-﻿namespace System.IO.Abstractions.TestingHelpers
+﻿using System.Security.AccessControl;
+
+namespace System.IO.Abstractions.TestingHelpers
 {
     [Serializable]
     public class MockDirectoryData : MockFileData
     {
+        [NonSerialized]
+        private DirectorySecurity accessControl = new DirectorySecurity();
+        
         public override bool IsDirectory { get { return true; } }
 
         public MockDirectoryData() : base(string.Empty)
         {
             Attributes = FileAttributes.Directory;
+        }
+        
+        public new DirectorySecurity AccessControl
+        {
+            get { return accessControl; }
+            set { accessControl = value; }
         }
     }
 }


### PR DESCRIPTION
Supercedes #259 (_meant to branch for the PR as opposed to creating on master_).

Add support for both getting and setting AccessControl on directories.

It looks like the implementation of `AddDirectory(string path)` on `MockFileSystem` should also accept a `MockDirectoryData` parameter, similar to how `AddFile(string path, MockFileData mockFile)` accepts `MockFileData`. This PR doesn't include that change