### PR TITLE
Added methods to handle loading data from embedded files

### DIFF
--- a/TestHelpers.Tests/MockFileSystemTests.cs
+++ b/TestHelpers.Tests/MockFileSystemTests.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Text;
 using NUnit.Framework;
 
 namespace System.IO.Abstractions.TestingHelpers.Tests
@@ -203,6 +205,33 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.Contains(@"C:\LOUD\SUBLOUD\new\file.txt", fileSystem.AllFiles.ToList());
             Assert.Contains(@"C:\test\subtest\new\SUBDirectory\", fileSystem.AllDirectories.ToList());
             Assert.Contains(@"C:\LOUD\SUBLOUD\new\SUBDirectory\", fileSystem.AllDirectories.ToList());
+        }
+
+        [Test]
+        public void MockFileSystem_AddFileFromEmbeddedResource_ShouldAddTheFile()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            fileSystem.AddFileFromEmbeddedResource(@"C:\TestFile.txt", Assembly.GetExecutingAssembly(), "System.IO.Abstractions.TestingHelpers.Tests.TestFiles.TestFile.txt");
+            var result = fileSystem.GetFile(@"C:\TestFile.txt");
+
+            // Assert
+            Assert.AreEqual(new UTF8Encoding().GetBytes("This is a test file."), result.Contents);
+        }
+
+        [Test]
+        public void MockFileSystem_AddFilesFromEmbeddedResource_ShouldAddAllTheFiles()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            //Act
+            fileSystem.AddFilesFromEmbeddedNamespace(@"C:\", Assembly.GetExecutingAssembly(), "System.IO.Abstractions.TestingHelpers.Tests.TestFiles");
+
+            Assert.Contains(@"C:\TestFile.txt", fileSystem.AllFiles.ToList());
+            Assert.Contains(@"C:\SecondTestFile.txt", fileSystem.AllFiles.ToList());
         }
     }
 }

--- a/TestHelpers.Tests/TestFiles/SecondTestFile.txt
+++ b/TestHelpers.Tests/TestFiles/SecondTestFile.txt
@@ -1,0 +1,1 @@
+This is a the second test file.

--- a/TestHelpers.Tests/TestFiles/TestFile.txt
+++ b/TestHelpers.Tests/TestFiles/TestFile.txt
@@ -1,0 +1,1 @@
+This is a test file.

--- a/TestHelpers.Tests/TestHelpers.Tests.csproj
+++ b/TestHelpers.Tests/TestHelpers.Tests.csproj
@@ -24,6 +24,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="TestFiles\SecondTestFile.txt" />
+    <None Remove="TestFiles\TestFile.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="TestFiles\SecondTestFile.txt" />
+    <EmbeddedResource Include="TestFiles\TestFile.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="../System.IO.Abstractions/System.IO.Abstractions.csproj" />
     <ProjectReference Include="../TestingHelpers/TestingHelpers.csproj" />
   </ItemGroup>

--- a/TestingHelpers/IMockFileDataAccessor.cs
+++ b/TestingHelpers/IMockFileDataAccessor.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Reflection;
 
 namespace System.IO.Abstractions.TestingHelpers
 {
@@ -16,6 +17,9 @@ namespace System.IO.Abstractions.TestingHelpers
 
         void AddFile(string path, MockFileData mockFile);
         void AddDirectory(string path);
+
+        void AddFileFromEmbeddedResource(string path, Assembly resourceAssembly, string embeddedResourcePath);
+        void AddFilesFromEmbeddedNamespace(string path, Assembly resourceAssembly, string embeddedRresourcePath);
 
         /// <summary>
         /// Removes the file.

--- a/TestingHelpers/MockFileSystem.cs
+++ b/TestingHelpers/MockFileSystem.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 
 namespace System.IO.Abstractions.TestingHelpers
 {
@@ -190,7 +191,40 @@ namespace System.IO.Abstractions.TestingHelpers
             }
         }
 
-        public void RemoveFile(string path)
+      public void AddFileFromEmbeddedResource(string path, Assembly resourceAssembly, string embeddedResourcePath)
+      {
+            using (var embeddedResourceStream = resourceAssembly.GetManifestResourceStream(embeddedResourcePath))
+            {
+                if (embeddedResourceStream == null)
+                {
+                    throw new Exception("Resource not found in assembly");
+                }
+
+                using (var streamReader = new BinaryReader(embeddedResourceStream))
+                {
+                    var fileData = streamReader.ReadBytes((int)embeddedResourceStream.Length);
+                    AddFile(path, new MockFileData(fileData));
+                }
+            }
+      }
+
+      public void AddFilesFromEmbeddedNamespace(string path, Assembly resourceAssembly, string embeddedRresourcePath)
+      {
+          var matchingResources = resourceAssembly.GetManifestResourceNames().Where(f => f.StartsWith(embeddedRresourcePath));
+          foreach (var resource in matchingResources)
+          {
+            using (var embeddedResourceStream = resourceAssembly.GetManifestResourceStream(resource))
+            using (var streamReader = new BinaryReader(embeddedResourceStream))
+            {
+                var fileName = resource.Substring(embeddedRresourcePath.Length + 1);
+                var fileData = streamReader.ReadBytes((int)embeddedResourceStream.Length);
+                var filePath = Path.Combine(path, fileName);
+                AddFile(filePath, new MockFileData(fileData));
+            }
+          }
+      }
+
+      public void RemoveFile(string path)
         {
             path = FixPath(path);
 


### PR DESCRIPTION
Adds two additional methods for the MockFileSystem class to allow embedded files to be added:
- AddFileFromEmbeddedResource - Adds an embedded file to the file system
- AddFilesFromEmbeddedNamespace - Adds all embedded files under a namespace