### PR TITLE
Use correct lock object for AllFiles

### DIFF
--- a/TestingHelpers/MockFileSystem.cs
+++ b/TestingHelpers/MockFileSystem.cs
@@ -256,7 +256,7 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             get
             {
-                lock (file)
+                lock (files)
                     return files.Where(f => !f.Value.IsDirectory).Select(f => f.Key).ToArray();
             }
         }


### PR DESCRIPTION
Avoid **"System.InvalidOperationException : Collection was modified; enumeration operation may not execute."**